### PR TITLE
Fix typo in kubefed init's example

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -105,7 +105,7 @@ var (
 		# Initialize federation control plane for a federation
 		# named foo in the host cluster whose local kubeconfig
 		# context is bar.
-		kubectl init foo --host-cluster-context=bar`)
+		kubefed init foo --host-cluster-context=bar`)
 
 	componentLabel = map[string]string{
 		"app": "federated-cluster",


### PR DESCRIPTION
Fix typo in kubefed init's example